### PR TITLE
9 Miao glyph variants added to source

### DIFF
--- a/sources/NotoSansMiao.glyphs
+++ b/sources/NotoSansMiao.glyphs
@@ -1,5 +1,8 @@
 {
-.appVersion = "3109";
+.appVersion = "3316";
+DisplayStrings = (
+"/u16F04.lpo/u16F10.lpo/u16F23.lpo/u16F33.lpo/u16F39.lpo/u16F57.lpo/u16F58.lpo/u16F72.lpo/u16F7E.lpo/space/space"
+);
 classes = (
 {
 code = "u16F00 u16F01 u16F02 u16F03 u16F04 u16F05 u16F06 u16F07 u16F08 u16F09 u16F0A u16F0B u16F0C u16F0D u16F0E u16F0F u16F10 u16F11 u16F12 u16F13 u16F14 u16F15 u16F16 u16F17 u16F18 u16F19 u16F1A u16F1B u16F1C u16F1D u16F1E u16F1F u16F20 u16F21 u16F22 u16F23 u16F24 u16F25 u16F26 u16F27 u16F28 u16F29 u16F2A u16F2B u16F2C u16F2D u16F2E u16F2F u16F30 u16F31 u16F32 u16F33 u16F34 u16F35 u16F36 u16F37 u16F38 u16F39 u16F3A u16F3B u16F3C u16F3D u16F3E u16F3F u16F40 u16F41 u16F42 u16F43 u16F44 u16F45 u16F46 u16F47 u16F48 u16F49 u16F4A u16F50 uni25CC";
@@ -432,6 +435,10 @@ value = (
 );
 },
 {
+name = "Use Typo Metrics";
+value = 1;
+},
+{
 name = description;
 value = "Designed by Monotype design team.";
 },
@@ -444,20 +451,16 @@ name = licenseURL;
 value = "https://scripts.sil.org/OFL";
 },
 {
-name = vendorID;
-value = GOOG;
-},
-{
 name = trademark;
 value = "Noto is a trademark of Google Inc.";
 },
 {
-name = versionString;
-value = "Version 2.003";
+name = vendorID;
+value = GOOG;
 },
 {
-name = "Use Typo Metrics";
-value = 1;
+name = versionString;
+value = "Version 2.003";
 }
 );
 date = "2017-11-08 21:24:25 +0000";
@@ -1120,7 +1123,7 @@ category = Letter;
 },
 {
 glyphname = u16F04;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 anchors = (
@@ -1572,7 +1575,7 @@ category = Letter;
 },
 {
 glyphname = u16F10;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 anchors = (
@@ -2358,7 +2361,7 @@ category = Letter;
 },
 {
 glyphname = u16F23;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 anchors = (
@@ -2369,6 +2372,16 @@ position = "{310, 785}";
 {
 name = Anchor4;
 position = "{300, 0}";
+}
+);
+guideLines = (
+{
+angle = 90;
+position = "{550, 396}";
+},
+{
+angle = 90;
+position = "{586, 396}";
 }
 );
 layerId = UUID0;
@@ -3058,7 +3071,7 @@ category = Letter;
 },
 {
 glyphname = u16F33;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 anchors = (
@@ -3303,7 +3316,7 @@ category = Letter;
 },
 {
 glyphname = u16F39;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 anchors = (
@@ -3699,7 +3712,7 @@ category = Letter;
 },
 {
 glyphname = u16F42;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:32:38 +0000";
 layers = (
 {
 anchors = (
@@ -3712,6 +3725,43 @@ name = Anchor4;
 position = "{360, 0}";
 }
 );
+background = {
+anchors = (
+{
+name = Anchor2;
+position = "{360, 785}";
+},
+{
+name = Anchor4;
+position = "{360, 0}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"551 -10 OFFCURVE",
+"640 104 OFFCURVE",
+"640 252 CURVE SMOOTH",
+"640 714 LINE",
+"550 714 LINE",
+"550 252 LINE SMOOTH",
+"550 144 OFFCURVE",
+"496 75 OFFCURVE",
+"367 75 CURVE SMOOTH",
+"242 75 OFFCURVE",
+"180 135 OFFCURVE",
+"180 251 CURVE SMOOTH",
+"180 714 LINE",
+"90 714 LINE",
+"90 254 LINE SMOOTH",
+"90 95 OFFCURVE",
+"184 -10 OFFCURVE",
+"362 -10 CURVE SMOOTH"
+);
+}
+);
+};
 layerId = UUID0;
 paths = (
 {
@@ -4038,7 +4088,7 @@ category = Letter;
 },
 {
 glyphname = u16F57;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -4081,7 +4131,7 @@ category = Letter;
 },
 {
 glyphname = u16F58;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5441,7 +5491,7 @@ category = Letter;
 },
 {
 glyphname = u16F72;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5874,7 +5924,7 @@ category = Letter;
 },
 {
 glyphname = u16F7E;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:36:00 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8597,7 +8647,7 @@ category = Letter;
 },
 {
 glyphname = u16F57.cnt;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:24 +0000";
 layers = (
 {
 components = (
@@ -8614,7 +8664,7 @@ category = Letter;
 },
 {
 glyphname = u16F58.cnt;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:24 +0000";
 layers = (
 {
 components = (
@@ -9056,7 +9106,7 @@ category = Letter;
 },
 {
 glyphname = u16F72.cnt;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:24 +0000";
 layers = (
 {
 components = (
@@ -9260,7 +9310,7 @@ category = Letter;
 },
 {
 glyphname = u16F7E.cnt;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:24 +0000";
 layers = (
 {
 components = (
@@ -9328,7 +9378,7 @@ category = Letter;
 },
 {
 glyphname = u16F57.rht;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:24 +0000";
 layers = (
 {
 components = (
@@ -9345,7 +9395,7 @@ category = Letter;
 },
 {
 glyphname = u16F58.rht;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:24 +0000";
 layers = (
 {
 components = (
@@ -9787,7 +9837,7 @@ category = Letter;
 },
 {
 glyphname = u16F72.rht;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 components = (
@@ -9991,7 +10041,7 @@ category = Letter;
 },
 {
 glyphname = u16F7E.rht;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 components = (
@@ -10104,7 +10154,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u16F57.abv;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 anchors = (
@@ -10136,7 +10186,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u16F58.abv;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 anchors = (
@@ -10968,7 +11018,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u16F72.abv;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 anchors = (
@@ -11352,7 +11402,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u16F7E.abv;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 anchors = (
@@ -11480,7 +11530,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u16F57.blw;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 anchors = (
@@ -11512,7 +11562,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u16F58.blw;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 anchors = (
@@ -12344,7 +12394,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u16F72.blw;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 anchors = (
@@ -12728,7 +12778,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u16F7E.blw;
-lastChange = "2019-09-10 21:03:33 +0000";
+lastChange = "2024-09-03 18:11:41 +0000";
 layers = (
 {
 anchors = (
@@ -14947,6 +14997,964 @@ transform = "{1, 0, 0, 1, 150, 0}";
 );
 layerId = UUID0;
 width = 150;
+}
+);
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F04.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor2;
+position = "{280, 785}";
+},
+{
+name = Anchor4;
+position = "{280, 0}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"191 725 OFFCURVE",
+"113 701 OFFCURVE",
+"52 628 CURVE",
+"120 570 LINE",
+"160 619 OFFCURVE",
+"212 641 OFFCURVE",
+"279 641 CURVE SMOOTH",
+"428 641 OFFCURVE",
+"500 535 OFFCURVE",
+"500 355 CURVE SMOOTH",
+"500 179 OFFCURVE",
+"426 75 OFFCURVE",
+"279 75 CURVE SMOOTH",
+"212 75 OFFCURVE",
+"160 97 OFFCURVE",
+"120 146 CURVE",
+"52 88 LINE",
+"113 15 OFFCURVE",
+"191 -9 OFFCURVE",
+"271 -9 CURVE SMOOTH",
+"477 -9 OFFCURVE",
+"595 136 OFFCURVE",
+"595 357 CURVE SMOOTH",
+"595 577 OFFCURVE",
+"475 725 OFFCURVE",
+"271 725 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"471 -9 OFFCURVE",
+"589 136 OFFCURVE",
+"589 357 CURVE SMOOTH",
+"589 577 OFFCURVE",
+"469 725 OFFCURVE",
+"273 725 CURVE SMOOTH",
+"199 725 OFFCURVE",
+"121 701 OFFCURVE",
+"60 628 CURVE",
+"128 570 LINE",
+"168 619 OFFCURVE",
+"220 641 OFFCURVE",
+"281 641 CURVE SMOOTH",
+"422 641 OFFCURVE",
+"494 535 OFFCURVE",
+"494 355 CURVE SMOOTH",
+"494 179 OFFCURVE",
+"420 75 OFFCURVE",
+"281 75 CURVE SMOOTH",
+"220 75 OFFCURVE",
+"168 97 OFFCURVE",
+"128 146 CURVE",
+"60 88 LINE",
+"121 15 OFFCURVE",
+"199 -9 OFFCURVE",
+"273 -9 CURVE SMOOTH"
+);
+}
+);
+width = 637;
+}
+);
+leftMetricsKey = u16F10.lpo;
+rightMetricsKey = u16F10.lpo;
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F10.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor2;
+position = "{369, 785}";
+},
+{
+name = Anchor4;
+position = "{348, 0}";
+}
+);
+background = {
+anchors = (
+{
+name = Anchor2;
+position = "{318, -315}";
+},
+{
+name = Anchor4;
+position = "{348, -1100}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"369 -10 LINE SMOOTH",
+"500 -10 OFFCURVE",
+"602 62 OFFCURVE",
+"602 183 CURVE SMOOTH",
+"602 295 OFFCURVE",
+"529 350 OFFCURVE",
+"403 397 CURVE SMOOTH",
+"287 440 OFFCURVE",
+"237 464 OFFCURVE",
+"237 536 CURVE SMOOTH",
+"237 598 OFFCURVE",
+"288 641 OFFCURVE",
+"370 641 CURVE SMOOTH",
+"433 641 OFFCURVE",
+"483 619 OFFCURVE",
+"527 570 CURVE",
+"597 630 LINE",
+"534 704 OFFCURVE",
+"458 725 OFFCURVE",
+"372 725 CURVE SMOOTH",
+"237 725 OFFCURVE",
+"142 649 OFFCURVE",
+"142 536 CURVE SMOOTH",
+"142 425 OFFCURVE",
+"218 374 OFFCURVE",
+"340 330 CURVE SMOOTH",
+"469 283 OFFCURVE",
+"507 253 OFFCURVE",
+"507 183 CURVE SMOOTH",
+"507 117 OFFCURVE",
+"455 75 OFFCURVE",
+"369 75 CURVE SMOOTH",
+"292 75 OFFCURVE",
+"237 106 OFFCURVE",
+"185 180 CURVE",
+"114 122 LINE",
+"185 19 OFFCURVE",
+"271 -10 OFFCURVE",
+"367 -10 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"450 -9 OFFCURVE",
+"528 15 OFFCURVE",
+"589 88 CURVE",
+"521 146 LINE",
+"481 97 OFFCURVE",
+"429 75 OFFCURVE",
+"368 75 CURVE SMOOTH",
+"227 75 OFFCURVE",
+"155 181 OFFCURVE",
+"155 361 CURVE SMOOTH",
+"155 537 OFFCURVE",
+"229 641 OFFCURVE",
+"368 641 CURVE SMOOTH",
+"429 641 OFFCURVE",
+"481 619 OFFCURVE",
+"521 570 CURVE",
+"589 628 LINE",
+"528 701 OFFCURVE",
+"450 725 OFFCURVE",
+"376 725 CURVE SMOOTH",
+"178 725 OFFCURVE",
+"60 580 OFFCURVE",
+"60 359 CURVE SMOOTH",
+"60 139 OFFCURVE",
+"180 -9 OFFCURVE",
+"376 -9 CURVE SMOOTH"
+);
+}
+);
+width = 637;
+}
+);
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F23.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor2;
+position = "{355, 785}";
+},
+{
+name = Anchor4;
+position = "{313, 0}";
+},
+{
+name = Anchor4_;
+position = "{350, 0}";
+}
+);
+background = {
+anchors = (
+{
+name = Anchor2;
+position = "{323, 785}";
+},
+{
+name = Anchor4;
+position = "{313, 0}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"353 714 LINE SMOOTH",
+"181 714 OFFCURVE",
+"80 652 OFFCURVE",
+"80 479 CURVE SMOOTH",
+"80 236 LINE SMOOTH",
+"80 73 OFFCURVE",
+"157 0 OFFCURVE",
+"329 0 CURVE SMOOTH",
+"571 0 LINE",
+"571 80 LINE",
+"329 80 LINE SMOOTH",
+"222 80 OFFCURVE",
+"170 116 OFFCURVE",
+"170 236 CURVE SMOOTH",
+"170 483 LINE SMOOTH",
+"170 587 OFFCURVE",
+"222 637 OFFCURVE",
+"314 634 CURVE",
+"299 609 OFFCURVE",
+"288 583 OFFCURVE",
+"288 549 CURVE SMOOTH",
+"288 463 OFFCURVE",
+"358 393 OFFCURVE",
+"448 393 CURVE SMOOTH",
+"538 393 OFFCURVE",
+"607 463 OFFCURVE",
+"607 549 CURVE SMOOTH",
+"607 635 OFFCURVE",
+"549 714 OFFCURVE",
+"386 714 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"493 629 OFFCURVE",
+"527 594 OFFCURVE",
+"527 549 CURVE SMOOTH",
+"527 505 OFFCURVE",
+"493 469 OFFCURVE",
+"448 469 CURVE SMOOTH",
+"404 469 OFFCURVE",
+"368 505 OFFCURVE",
+"368 549 CURVE SMOOTH",
+"368 594 OFFCURVE",
+"404 629 OFFCURVE",
+"448 629 CURVE SMOOTH"
+);
+}
+);
+};
+guideLines = (
+{
+angle = 90;
+position = "{571, 396}";
+},
+{
+angle = 90;
+position = "{607, 396}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"549 0 OFFCURVE",
+"607 79 OFFCURVE",
+"607 165 CURVE SMOOTH",
+"607 251 OFFCURVE",
+"538 321 OFFCURVE",
+"448 321 CURVE SMOOTH",
+"358 321 OFFCURVE",
+"288 251 OFFCURVE",
+"288 165 CURVE SMOOTH",
+"288 131 OFFCURVE",
+"299 102 OFFCURVE",
+"322 80 CURVE",
+"229 80 OFFCURVE",
+"170 116 OFFCURVE",
+"170 231 CURVE SMOOTH",
+"170 478 LINE SMOOTH",
+"170 598 OFFCURVE",
+"222 634 OFFCURVE",
+"329 634 CURVE SMOOTH",
+"571 634 LINE",
+"571 714 LINE",
+"329 714 LINE SMOOTH",
+"157 714 OFFCURVE",
+"80 641 OFFCURVE",
+"80 478 CURVE SMOOTH",
+"80 236 LINE SMOOTH",
+"80 73 OFFCURVE",
+"157 0 OFFCURVE",
+"329 0 CURVE SMOOTH",
+"386 0 LINE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 85 OFFCURVE",
+"368 120 OFFCURVE",
+"368 165 CURVE SMOOTH",
+"368 209 OFFCURVE",
+"404 245 OFFCURVE",
+"448 245 CURVE SMOOTH",
+"493 245 OFFCURVE",
+"527 209 OFFCURVE",
+"527 165 CURVE SMOOTH",
+"527 120 OFFCURVE",
+"493 85 OFFCURVE",
+"448 85 CURVE SMOOTH"
+);
+}
+);
+width = 657;
+}
+);
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F33.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor2;
+position = "{266, 785}";
+},
+{
+name = Anchor4;
+position = "{228, 0}";
+}
+);
+background = {
+anchors = (
+{
+name = Anchor2;
+position = "{208, 785}";
+},
+{
+name = Anchor4;
+position = "{228, 0}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"327 -10 OFFCURVE",
+"401 53 OFFCURVE",
+"401 191 CURVE SMOOTH",
+"401 714 LINE",
+"311 714 LINE",
+"311 184 LINE SMOOTH",
+"311 93 OFFCURVE",
+"268 75 OFFCURVE",
+"218 75 CURVE SMOOTH",
+"166 75 OFFCURVE",
+"136 106 OFFCURVE",
+"119 156 CURVE",
+"38 118 LINE",
+"63 43 OFFCURVE",
+"117 -10 OFFCURVE",
+"218 -10 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"317 -10 OFFCURVE",
+"365 58 OFFCURVE",
+"408 204 CURVE SMOOTH",
+"558 714 LINE",
+"466 714 LINE",
+"318 208 LINE SMOOTH",
+"288 106 OFFCURVE",
+"262 75 OFFCURVE",
+"210 75 CURVE SMOOTH",
+"155 75 OFFCURVE",
+"126 108 OFFCURVE",
+"111 156 CURVE",
+"30 118 LINE",
+"55 43 OFFCURVE",
+"113 -10 OFFCURVE",
+"208 -10 CURVE SMOOTH"
+);
+}
+);
+width = 588;
+}
+);
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F39.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor2;
+position = "{230, 785}";
+},
+{
+name = Anchor4;
+position = "{220, 0}";
+}
+);
+background = {
+anchors = (
+{
+name = Anchor2;
+position = "{230, 785}";
+},
+{
+name = Anchor4;
+position = "{220, 0}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"419 0 LINE",
+"419 80 LINE",
+"270 80 LINE",
+"270 411 LINE",
+"420 411 LINE",
+"420 491 LINE",
+"270 491 LINE",
+"270 714 LINE",
+"180 714 LINE",
+"180 491 LINE",
+"30 491 LINE",
+"30 411 LINE",
+"180 411 LINE",
+"180 0 LINE"
+);
+}
+);
+};
+guideLines = (
+{
+angle = 90;
+position = "{420, 455}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"419 0 LINE",
+"419 80 LINE",
+"270 80 LINE",
+"270 411 LINE",
+"420 411 LINE",
+"420 491 LINE",
+"270 491 LINE",
+"270 714 LINE",
+"180 714 LINE",
+"180 491 LINE",
+"30 491 LINE",
+"30 411 LINE",
+"180 411 LINE",
+"180 0 LINE"
+);
+}
+);
+width = 468;
+}
+);
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F57.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"288 -10 OFFCURVE",
+"352 50 OFFCURVE",
+"352 125 CURVE",
+"284 125 LINE",
+"284 84 OFFCURVE",
+"254 54 OFFCURVE",
+"213 54 CURVE SMOOTH",
+"173 54 OFFCURVE",
+"142 84 OFFCURVE",
+"142 125 CURVE SMOOTH",
+"142 166 OFFCURVE",
+"171 195 OFFCURVE",
+"208 198 CURVE SMOOTH",
+"214 198 LINE",
+"214 258 LINE",
+"0 258 LINE",
+"0 198 LINE",
+"110 198 LINE",
+"87 178 OFFCURVE",
+"74 153 OFFCURVE",
+"74 125 CURVE SMOOTH",
+"74 50 OFFCURVE",
+"138 -10 OFFCURVE",
+"213 -10 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"307 0 LINE",
+"307 64 LINE",
+"223 64 LINE SMOOTH",
+"198 64 OFFCURVE",
+"142 70 OFFCURVE",
+"142 128 CURVE SMOOTH",
+"142 164 OFFCURVE",
+"169 198 OFFCURVE",
+"211 198 CURVE SMOOTH",
+"214 198 LINE",
+"214 258 LINE",
+"0 258 LINE",
+"0 198 LINE",
+"151 198 LINE",
+"134 214 LINE",
+"85 189 OFFCURVE",
+"74 156 OFFCURVE",
+"74 118 CURVE SMOOTH",
+"74 58 OFFCURVE",
+"109 0 OFFCURVE",
+"216 0 CURVE SMOOTH"
+);
+}
+);
+width = 357;
+}
+);
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F58.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"157 134 OFFCURVE",
+"198 167 OFFCURVE",
+"256 167 CURVE SMOOTH",
+"312 167 OFFCURVE",
+"356 129 OFFCURVE",
+"356 77 CURVE SMOOTH",
+"356 18 OFFCURVE",
+"302 -15 OFFCURVE",
+"233 -15 CURVE SMOOTH",
+"145 -15 OFFCURVE",
+"71 24 OFFCURVE",
+"71 107 CURVE SMOOTH",
+"71 147 OFFCURVE",
+"85 178 OFFCURVE",
+"107 198 CURVE",
+"0 198 LINE",
+"0 258 LINE",
+"214 258 LINE",
+"214 198 LINE",
+"149 193 OFFCURVE",
+"135 137 OFFCURVE",
+"135 108 CURVE SMOOTH",
+"135 77 OFFCURVE",
+"143 42 OFFCURVE",
+"180 30 CURVE",
+"189 38 LINE",
+"220 34 LINE",
+"253 33 LINE",
+"285 33 OFFCURVE",
+"304 53 OFFCURVE",
+"304 78 CURVE SMOOTH",
+"304 101 OFFCURVE",
+"285 123 OFFCURVE",
+"253 123 CURVE SMOOTH",
+"221 123 OFFCURVE",
+"204 101 OFFCURVE",
+"204 78 CURVE SMOOTH",
+"204 53 OFFCURVE",
+"221 33 OFFCURVE",
+"253 33 CURVE",
+"196 19 LINE",
+"165 36 OFFCURVE",
+"157 59 OFFCURVE",
+"157 78 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"300 -10 OFFCURVE",
+"356 21 OFFCURVE",
+"356 81 CURVE SMOOTH",
+"356 134 OFFCURVE",
+"312 167 OFFCURVE",
+"253 167 CURVE SMOOTH",
+"199 167 OFFCURVE",
+"157 138 OFFCURVE",
+"157 86 CURVE SMOOTH",
+"157 68 OFFCURVE",
+"163 56 OFFCURVE",
+"171 46 CURVE",
+"169 44 LINE",
+"147 57 OFFCURVE",
+"135 82 OFFCURVE",
+"135 108 CURVE SMOOTH",
+"135 137 OFFCURVE",
+"149 193 OFFCURVE",
+"214 198 CURVE",
+"214 258 LINE",
+"0 258 LINE",
+"0 198 LINE",
+"114 198 LINE",
+"86 178 OFFCURVE",
+"71 141 OFFCURVE",
+"71 106 CURVE SMOOTH",
+"71 27 OFFCURVE",
+"141 -10 OFFCURVE",
+"230 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 37 OFFCURVE",
+"206 55 OFFCURVE",
+"206 79 CURVE SMOOTH",
+"206 103 OFFCURVE",
+"223 121 OFFCURVE",
+"253 121 CURVE SMOOTH",
+"283 121 OFFCURVE",
+"302 103 OFFCURVE",
+"302 79 CURVE SMOOTH",
+"302 55 OFFCURVE",
+"283 37 OFFCURVE",
+"253 37 CURVE SMOOTH"
+);
+}
+);
+width = 406;
+}
+);
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F72.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"231 -4 OFFCURVE",
+"254 82 OFFCURVE",
+"254 157 CURVE SMOOTH",
+"254 235 OFFCURVE",
+"190 268 OFFCURVE",
+"117 268 CURVE SMOOTH",
+"44 268 OFFCURVE",
+"-17 232 OFFCURVE",
+"-17 180 CURVE SMOOTH",
+"-17 129 OFFCURVE",
+"42 89 OFFCURVE",
+"115 89 CURVE SMOOTH",
+"138 89 OFFCURVE",
+"161 93 OFFCURVE",
+"180 100 CURVE",
+"174 67 OFFCURVE",
+"146 46 OFFCURVE",
+"110 46 CURVE",
+"115 -10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 141 OFFCURVE",
+"49 156 OFFCURVE",
+"49 178 CURVE SMOOTH",
+"49 201 OFFCURVE",
+"80 216 OFFCURVE",
+"117 216 CURVE SMOOTH",
+"156 216 OFFCURVE",
+"186 202 OFFCURVE",
+"186 178 CURVE SMOOTH",
+"186 156 OFFCURVE",
+"156 141 OFFCURVE",
+"117 141 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"181 124 LINE",
+"167 82 OFFCURVE",
+"124 54 OFFCURVE",
+"69 37 CURVE",
+"103 -12 LINE",
+"160 6 OFFCURVE",
+"247 55 OFFCURVE",
+"247 153 CURVE SMOOTH",
+"247 234 OFFCURVE",
+"189 268 OFFCURVE",
+"117 268 CURVE SMOOTH",
+"46 268 OFFCURVE",
+"0 229 OFFCURVE",
+"0 175 CURVE SMOOTH",
+"0 125 OFFCURVE",
+"37 88 OFFCURVE",
+"98 88 CURVE SMOOTH",
+"143 88 OFFCURVE",
+"170 111 OFFCURVE",
+"179 125 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"85 141 OFFCURVE",
+"66 156 OFFCURVE",
+"66 178 CURVE SMOOTH",
+"66 201 OFFCURVE",
+"86 216 OFFCURVE",
+"118 216 CURVE SMOOTH",
+"150 216 OFFCURVE",
+"170 202 OFFCURVE",
+"170 179 CURVE SMOOTH",
+"170 156 OFFCURVE",
+"150 141 OFFCURVE",
+"118 141 CURVE SMOOTH"
+);
+}
+);
+width = 297;
+}
+);
+category = Letter;
+},
+{
+color = 4;
+glyphname = u16F7E.lpo;
+lastChange = "2024-09-03 18:40:30 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"193 -510 OFFCURVE",
+"254 -474 OFFCURVE",
+"254 -422 CURVE SMOOTH",
+"254 -371 OFFCURVE",
+"195 -331 OFFCURVE",
+"122 -331 CURVE SMOOTH",
+"99 -331 OFFCURVE",
+"76 -335 OFFCURVE",
+"57 -342 CURVE",
+"63 -309 OFFCURVE",
+"77 -280 OFFCURVE",
+"122 -269 CURVE",
+"106 -212 LINE",
+"0 -236 OFFCURVE",
+"-15 -329 OFFCURVE",
+"-15 -380 CURVE SMOOTH",
+"-15 -478 OFFCURVE",
+"47 -510 OFFCURVE",
+"120 -510 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"81 -458 OFFCURVE",
+"51 -444 OFFCURVE",
+"51 -420 CURVE SMOOTH",
+"51 -398 OFFCURVE",
+"81 -383 OFFCURVE",
+"120 -383 CURVE SMOOTH",
+"157 -383 OFFCURVE",
+"188 -398 OFFCURVE",
+"188 -420 CURVE SMOOTH",
+"188 -443 OFFCURVE",
+"157 -458 OFFCURVE",
+"120 -458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"66 132 LINE",
+"80 174 OFFCURVE",
+"123 202 OFFCURVE",
+"178 219 CURVE",
+"144 268 LINE",
+"87 250 OFFCURVE",
+"0 201 OFFCURVE",
+"0 103 CURVE SMOOTH",
+"0 22 OFFCURVE",
+"58 -12 OFFCURVE",
+"130 -12 CURVE SMOOTH",
+"201 -12 OFFCURVE",
+"247 27 OFFCURVE",
+"247 81 CURVE SMOOTH",
+"247 131 OFFCURVE",
+"210 168 OFFCURVE",
+"149 168 CURVE SMOOTH",
+"104 168 OFFCURVE",
+"77 145 OFFCURVE",
+"68 131 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 115 OFFCURVE",
+"181 100 OFFCURVE",
+"181 78 CURVE SMOOTH",
+"181 55 OFFCURVE",
+"161 40 OFFCURVE",
+"129 40 CURVE SMOOTH",
+"97 40 OFFCURVE",
+"77 54 OFFCURVE",
+"77 77 CURVE SMOOTH",
+"77 100 OFFCURVE",
+"97 115 OFFCURVE",
+"129 115 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"201 -12 OFFCURVE",
+"247 27 OFFCURVE",
+"247 82 CURVE SMOOTH",
+"247 131 OFFCURVE",
+"211 168 OFFCURVE",
+"151 168 CURVE SMOOTH",
+"106 168 OFFCURVE",
+"77 145 OFFCURVE",
+"68 129 CURVE",
+"66 130 LINE",
+"80 174 OFFCURVE",
+"123 202 OFFCURVE",
+"178 219 CURVE",
+"144 268 LINE",
+"90 250 OFFCURVE",
+"0 201 OFFCURVE",
+"0 100 CURVE SMOOTH",
+"0 22 OFFCURVE",
+"58 -12 OFFCURVE",
+"132 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"97 40 OFFCURVE",
+"77 54 OFFCURVE",
+"77 77 CURVE SMOOTH",
+"77 100 OFFCURVE",
+"97 115 OFFCURVE",
+"129 115 CURVE SMOOTH",
+"162 115 OFFCURVE",
+"181 100 OFFCURVE",
+"181 78 CURVE SMOOTH",
+"181 55 OFFCURVE",
+"161 40 OFFCURVE",
+"129 40 CURVE SMOOTH"
+);
+}
+);
+width = 297;
 }
 );
 category = Letter;


### PR DESCRIPTION
9 Miao glyphs added, including /u16F04.lpo, /u16F10.lpo, /u16F23.lpo, /u16F33.lpo, /u16F39.lpo, /u16F57.lpo, /u16F58.lpo, /u16F72.lpo, /u16F7E.lpo.

![Screenshot 2024-09-03 at 8 40 39 PM](https://github.com/user-attachments/assets/cacbc08b-8c84-463b-82a9-dfe2316e6e77)

These additions have been named with a '.lpo' suffix and will act as alternates to support the Lipo language. Metrics for the four small vowels signs have been kept as LSB=0 & RSB=50 to follow the established glyph-set (even though I disagree with this approach to spacing).


